### PR TITLE
Fix/wrongly typed query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ parameter is the query label, the third parameter is the callback that returns a
 Query_Registry::set(
     'collection_prompts', // Query name
     'Collection Prompts', // Query label
-    function(array $args, $query_obj, Query $query) { // Callback for query args
+    function(array $args, \Bricks\Query $query_obj, juvo\Bricks_Custom_Queries\Query $query) { // Callback for query args
         return array_merge($args, [
                 'post_type' => 'posts',
             ]
@@ -81,7 +81,7 @@ You don´t need to set the tab.
 Query_Registry::set(
     'collection_prompts', // Query name
     'Collection Prompts', // Query label
-    function(array $args, $query_obj, Query $query) { // Callback for query args
+    function(array $args, \Bricks\Query $query_obj, juvo\Bricks_Custom_Queries\Query $query) { // Callback for query args
         
         // Check setting and apply your logic
         if (!empty($query_obj->settings['return_all'])) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -54,12 +54,12 @@ class Query {
 	/**
 	 * Callback that actually runs our query
 	 *
-	 * @param array $results
+	 * @param mixed Results of the query. Mostly an array, but sometimes false especially in ACF loops
 	 * @param \Bricks\Query $query_obj
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public function bricks_query( array $results, \Bricks\Query $query_obj ): array {
+	public function bricks_query( mixed $results, \Bricks\Query $query_obj ): mixed {
 
 		// Only modify queries for benefits
 		if ( $query_obj->object_type !== $this->name ) {


### PR DESCRIPTION
Sometimes the "results" paremter of https://academy.bricksbuilder.io/article/filter-bricks-query-run/ is not an array but false or null. This is especially the case when inside acf loops etc. Without the strong typing, the callback is more flexible.